### PR TITLE
feat: add standalone executable build support

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,5 +1,6 @@
 node_modules/
 data/
+dist/
 *.log
 .DS_Store
 

--- a/BUILD.md
+++ b/BUILD.md
@@ -1,0 +1,168 @@
+# Building MindSpark as a Standalone Executable
+
+This guide explains how to package MindSpark into a standalone executable (`.exe` for Windows, or native binaries for macOS/Linux) that can be distributed and run without requiring Node.js to be installed.
+
+## Prerequisites
+
+- **Node.js >= 22** (required for built-in `node:sqlite`)
+- **npm** (comes with Node.js)
+
+## Quick Build
+
+```bash
+# Install dev dependencies (just pkg + wrangler)
+npm install
+
+# Build for Windows (cross-compile works from any OS)
+npm run build:win
+
+# Build for macOS
+npm run build:mac
+
+# Build for Linux
+npm run build:linux
+
+# Build for current platform (auto-detect)
+npm run build:exe
+```
+
+The output binary will be in the `dist/` directory.
+
+## What Gets Packaged
+
+The executable bundles:
+- The Node.js 22 runtime (with built-in SQLite support)
+- `server.js` — the zero-dependency HTTP + SQLite API server
+- `launcher.js` — entry point that starts the server and opens your browser
+- `public/` — all frontend assets (index.html, app.js, styles.css, demo-map.json, etc.)
+
+The SQLite **database file** (`data/mindspark.db`) is NOT bundled — it's created at runtime in a `data/` folder next to wherever the executable is placed.
+
+## Running the Executable
+
+### Windows
+```
+mindspark.exe
+```
+
+### macOS / Linux
+```bash
+chmod +x mindspark-macos   # or mindspark-linux
+./mindspark-macos
+```
+
+On first launch:
+1. The app starts a local HTTP server on port 3000
+2. Your default browser opens automatically to `http://localhost:3000`
+3. A `data/` folder is created next to the executable containing your SQLite database
+
+### Configuration
+
+Set environment variables before running:
+
+| Variable     | Default                        | Description                          |
+|--------------|--------------------------------|--------------------------------------|
+| `PORT`       | `3000`                         | HTTP port for the server             |
+| `DB_PATH`    | `<exe_dir>/data/mindspark.db`  | Path to the SQLite database file     |
+| `NO_BROWSER` | *(unset)*                      | Set to `1` to skip auto-opening browser |
+
+Example (Windows):
+```cmd
+set PORT=8080
+set NO_BROWSER=1
+mindspark.exe
+```
+
+Example (Linux/macOS):
+```bash
+PORT=8080 NO_BROWSER=1 ./mindspark-linux
+```
+
+## Build Targets
+
+The `pkg` configuration supports cross-compilation. You can build for any platform from any platform:
+
+| Script            | Target                  | Output File          |
+|-------------------|-------------------------|----------------------|
+| `npm run build:win`   | Windows x64        | `dist/mindspark.exe`   |
+| `npm run build:mac`   | macOS x64          | `dist/mindspark-macos` |
+| `npm run build:linux` | Linux x64          | `dist/mindspark-linux` |
+| `npm run build:exe`   | Current platform   | `dist/mindspark`       |
+
+## File Structure After Build
+
+```
+dist/
+└── mindspark.exe          # The standalone executable (~80-100 MB)
+
+# When the user runs it, this appears next to the exe:
+data/
+└── mindspark.db           # SQLite database (created at runtime)
+```
+
+## How It Works
+
+[`@yao-pkg/pkg`](https://github.com/yao-pkg/pkg) packages the Node.js runtime, your JavaScript source files, and static assets into a single executable. The key points:
+
+1. **Entry point:** `launcher.js` is the `"bin"` field in `package.json` — pkg uses this as the main entry.
+2. **Assets:** The `"pkg.assets"` field tells pkg to bundle everything in `public/` into the executable's virtual filesystem (snapshot).
+3. **Runtime paths:** Inside the exe, `__dirname` resolves to the snapshot path. `launcher.js` sets `PUBLIC` to point inside the snapshot and `DB_PATH` to point to the real filesystem (next to the exe).
+4. **SQLite:** Since Node 22's `node:sqlite` is compiled into the Node binary itself (not a native addon), it works seamlessly inside the pkg executable.
+
+## Troubleshooting
+
+### "ERR_UNKNOWN_BUILTIN_MODULE: node:sqlite"
+This means the pkg-fetched Node binary doesn't include `node:sqlite`. Ensure you're targeting Node 22+:
+```bash
+pkg . --target node22-win-x64 --output dist/mindspark.exe
+```
+
+### Port already in use
+Another instance is running, or another app is using port 3000. Set a different port:
+```cmd
+set PORT=3001
+mindspark.exe
+```
+
+### Database permission errors
+Make sure the executable has write permissions in its directory (to create the `data/` folder). On Windows, avoid running from `C:\Program Files\` — place it in a user-writable location.
+
+### Browser doesn't open automatically
+Set `NO_BROWSER=1` and manually navigate to `http://localhost:3000` (or your configured port).
+
+## Alternative: Node.js Single Executable Application (SEA)
+
+Node.js 22+ also has a built-in [Single Executable Application](https://nodejs.org/api/single-executable-applications.html) feature. This is more experimental but doesn't require `pkg`:
+
+```bash
+# 1. Create SEA config
+echo '{"main":"launcher.js","output":"sea-prep.blob"}' > sea-config.json
+
+# 2. Generate the blob
+node --experimental-sea-config sea-config.json
+
+# 3. Copy the Node binary (on Windows)
+copy "C:\Program Files\nodejs\node.exe" mindspark.exe
+
+# 4. Remove the signature (Windows only)
+signtool remove /s mindspark.exe
+
+# 5. Inject the blob
+npx postject mindspark.exe NODE_SEA_BLOB sea-prep.blob ^
+  --sentinel-fuse NODE_SEA_FUSE_fce680ab2cc467b6e072b8b5df1996b2
+
+# 6. Re-sign (optional, Windows only)
+signtool sign /fd SHA256 mindspark.exe
+```
+
+**Limitation:** SEA bundles only a single JS file. You would need to inline the `public/` assets into the JS or use SEA's asset blob feature. The `pkg` approach is simpler for this project.
+
+## Distribution
+
+To distribute the built executable:
+
+1. Build with `npm run build:win`
+2. Zip the `dist/mindspark.exe` file
+3. Share the zip — recipients just extract and double-click
+
+No Node.js installation required on the target machine. The entire runtime is self-contained.

--- a/launcher.js
+++ b/launcher.js
@@ -1,0 +1,101 @@
+#!/usr/bin/env node
+/**
+ * MindSpark Launcher — entry point for the standalone executable.
+ *
+ * This wrapper:
+ *  1. Starts the MindSpark HTTP server (server.js)
+ *  2. Automatically opens the user's default browser to the app URL
+ *  3. Handles graceful shutdown on Ctrl+C / SIGTERM
+ *
+ * When packaged with `pkg`, static assets in public/ are bundled inside the
+ * executable via the snapshot filesystem. The database file (data/mindspark.db)
+ * is created in the working directory at runtime.
+ */
+'use strict';
+
+const { execSync } = require('node:child_process');
+const path = require('node:path');
+const os = require('node:os');
+
+// ---- Configuration -------------------------------------------------------
+const PORT = process.env.PORT || 3000;
+const OPEN_BROWSER = process.env.NO_BROWSER !== '1';
+
+// ---- Open browser (cross-platform) --------------------------------------
+function openBrowser(url) {
+  try {
+    const platform = os.platform();
+    if (platform === 'win32') {
+      execSync(`start "" "${url}"`, { stdio: 'ignore', shell: true });
+    } else if (platform === 'darwin') {
+      execSync(`open "${url}"`, { stdio: 'ignore' });
+    } else {
+      // Linux / other — try xdg-open, then sensible-browser
+      try {
+        execSync(`xdg-open "${url}"`, { stdio: 'ignore' });
+      } catch {
+        execSync(`sensible-browser "${url}"`, { stdio: 'ignore' });
+      }
+    }
+  } catch {
+    // Silently ignore if we can't open a browser (headless server, etc.)
+  }
+}
+
+// ---- Start the server ----------------------------------------------------
+console.log(`
+  ╔══════════════════════════════════════════════════╗
+  ║           MindSpark — Desktop Edition            ║
+  ╚══════════════════════════════════════════════════╝
+`);
+
+// When running as a pkg executable, __dirname points to the snapshot.
+// server.js uses __dirname to find PUBLIC and DB_PATH, which works correctly
+// for PUBLIC (inside snapshot). For DB_PATH we override to use real filesystem.
+const isPkg = typeof process.pkg !== 'undefined';
+
+if (isPkg) {
+  // Inside pkg, __dirname is the snapshot path (e.g. /snapshot/mindspark/)
+  // PUBLIC should resolve inside the snapshot (where assets are bundled).
+  process.env.PUBLIC = process.env.PUBLIC || path.join(__dirname, 'public');
+
+  // Database should be in the real filesystem (next to the exe), not inside the snapshot.
+  if (!process.env.DB_PATH) {
+    const exeDir = path.dirname(process.execPath);
+    process.env.DB_PATH = path.join(exeDir, 'data', 'mindspark.db');
+  }
+}
+
+process.env.PORT = String(PORT);
+
+// Start the server by requiring it (this triggers server.listen())
+const serverUrl = `http://localhost:${PORT}`;
+
+// Give the server a moment to bind, then open the browser
+const startDelay = 500; // ms
+
+try {
+  require('./server.js');
+
+  if (OPEN_BROWSER) {
+    setTimeout(() => {
+      console.log(`  Opening browser → ${serverUrl}\n`);
+      openBrowser(serverUrl);
+    }, startDelay);
+  }
+} catch (err) {
+  console.error('\n  Failed to start MindSpark server:\n');
+  console.error(' ', err.message || err);
+  console.error('\n  If you see a "node:sqlite" error, make sure this executable');
+  console.error('  was built with Node.js >= 22 which includes built-in SQLite.\n');
+  process.exit(1);
+}
+
+// ---- Graceful shutdown ---------------------------------------------------
+function shutdown() {
+  console.log('\n  Shutting down MindSpark...');
+  process.exit(0);
+}
+
+process.on('SIGINT', shutdown);
+process.on('SIGTERM', shutdown);

--- a/package.json
+++ b/package.json
@@ -4,16 +4,31 @@
   "description": "Open-source, self-hostable mind mapping app with a SQLite database backend. Zero dependencies, no restrictions.",
   "license": "MIT",
   "main": "server.js",
+  "bin": "launcher.js",
   "scripts": {
     "start": "node --disable-warning=ExperimentalWarning server.js",
     "dev": "node --disable-warning=ExperimentalWarning --watch server.js",
     "deploy": "wrangler deploy",
-    "preview": "wrangler dev"
+    "preview": "wrangler dev",
+    "build:exe": "pkg . --output dist/mindspark",
+    "build:win": "pkg . --target node22-win-x64 --output dist/mindspark.exe",
+    "build:mac": "pkg . --target node22-macos-x64 --output dist/mindspark-macos",
+    "build:linux": "pkg . --target node22-linux-x64 --output dist/mindspark-linux"
+  },
+  "pkg": {
+    "assets": [
+      "public/**/*"
+    ],
+    "targets": [
+      "node22-win-x64"
+    ],
+    "outputPath": "dist"
   },
   "engines": {
     "node": ">=22"
   },
   "devDependencies": {
+    "@yao-pkg/pkg": "^6.0.0",
     "wrangler": "^4.100.0"
   }
 }


### PR DESCRIPTION
Adds support for packaging MindSpark as a standalone executable
(.exe for Windows, native binaries for macOS/Linux) via @yao-pkg/pkg
— no local Node.js install required to run it.

- `launcher.js` — entry point: starts the server, opens the default
  browser, and resolves paths correctly whether running as a plain
  script or inside a packaged binary (assets from the pkg snapshot,
  the SQLite database from the real filesystem next to the executable)
- `BUILD.md` — build, run, configuration, and troubleshooting guide
- `package.json` — `build:win`/`build:mac`/`build:linux`/`build:exe`
  scripts and pkg config
- `.gitignore` — excludes build output (`dist/`)