### PR TITLE
fix: the import endpoint in worker/import-core in import-core.js

### DIFF
--- a/worker/import-core.js
+++ b/worker/import-core.js
@@ -22,7 +22,7 @@ export async function handleImport(request, env){
   if (env.IMPORT_TOKEN && request.headers.get('Authorization') !== `Bearer ${env.IMPORT_TOKEN}`)
     return J(401, { error: 'unauthorized' });
 
-  let spec; try { spec = await request.json(); } catch (e) { return J(400, { error: 'body must be valid JSON' }); }
+  let spec; try { const _t = await request.text(); spec = JSON.parse(_t, (k, v) => (k === '__proto__' || k === 'constructor') ? undefined : v); } catch (e) { return J(400, { error: 'body must be valid JSON' }); }
   let map;  try { map = buildMapFromSpec(spec); } catch (e) { return J(400, { error: String(e && e.message || e) }); }
 
   // Same shape as the app's _shareePayload(); the shared view runs autoLayout()


### PR DESCRIPTION
## Summary
Fix high severity security issue in `worker/import-core.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `worker/import-core.js:25` |
| **Assessment** | Likely exploitable |

**Description**: The import endpoint in worker/import-core.js parses JSON from the request body without validating or sanitizing the parsed object before processing. An attacker can send a JSON payload containing __proto__ or constructor properties to pollute the Object prototype, potentially affecting all objects in the application runtime.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `worker/import-core.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path, and the project's existing tests still pass, so intended behavior is unchanged.

## Verification
- [x] Build passes
- [x] Scanner re-scan confirms fix
- [x] LLM code review passed

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
