### PR TITLE
Add test suite and CI

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -1,0 +1,77 @@
+---
+name: CI
+
+on:
+  push:
+    branches: [main]
+  pull_request:
+  workflow_dispatch:
+
+# Read-only: this workflow never publishes anything.
+permissions:
+  contents: read
+
+jobs:
+  test:
+    name: Tests and syntax checks
+    runs-on: ubuntu-latest
+    steps:
+      - name: Check out the repository
+        uses: actions/checkout@v7.0.0
+
+      - name: Set up Node.js
+        uses: actions/setup-node@v4
+        with:
+          node-version: '22'
+
+      # No `npm ci` — the app itself has zero runtime dependencies and the
+      # tests use only node:test, so there is nothing to install. This also
+      # keeps CI from failing on an out-of-sync lockfile, which is unrelated
+      # to whether the code works.
+
+      - name: Run tests
+        run: npm test
+
+      # public/app.js is a browser script, not a module, so it can't be
+      # imported — but `node --check` still catches syntax errors in it,
+      # which is the failure mode that would break the whole app at load.
+      - name: Syntax-check all JavaScript
+        run: |
+          # Written to a file rather than piped: a `... | while read` loop runs
+          # in a subshell, so the fail flag set inside it would be lost.
+          git ls-files '*.js' '*.mjs' | grep -v '^dist/' > /tmp/js-files.txt
+          echo "checking $(wc -l < /tmp/js-files.txt) files"
+          fail=0
+          while IFS= read -r f; do
+            node --check "$f" || { echo "::error file=$f::syntax error"; fail=1; }
+          done < /tmp/js-files.txt
+          exit $fail
+
+      - name: Validate workflow and issue-template YAML
+        run: |
+          python3 - <<'PY'
+          import sys, glob, yaml
+          bad = []
+          for f in glob.glob('.github/**/*.yml', recursive=True) + glob.glob('.github/**/*.yaml', recursive=True):
+              try:
+                  yaml.safe_load(open(f))
+              except Exception as e:
+                  bad.append((f, e))
+                  print(f"::error file={f}::invalid YAML: {e}")
+          sys.exit(1 if bad else 0)
+          PY
+
+      - name: Check the server actually boots and serves the app
+        run: |
+          node --disable-warning=ExperimentalWarning server.js &
+          pid=$!
+          for i in $(seq 1 20); do
+            sleep 0.5
+            curl -fsS -o /dev/null http://localhost:3000/ && break
+          done
+          for path in / /app.js /styles.css /api/maps; do
+            code=$(curl -s -o /dev/null -w '%{http_code}' "http://localhost:3000$path")
+            echo "  $path -> $code"
+            [ "$code" = "200" ] || { echo "::error::$path returned $code"; kill $pid; exit 1; }
+          done
+          kill $pid

--- a/package.json
+++ b/package.json
@@ -8,6 +8,7 @@
   "scripts": {
     "start": "node --disable-warning=ExperimentalWarning server.js",
     "dev": "node --disable-warning=ExperimentalWarning --watch server.js",
+    "test": "node --test \"test/*.test.mjs\"",
     "deploy": "wrangler deploy",
     "preview": "wrangler dev",
     "build:exe": "pkg . --output dist/mindspark",

--- a/test/app-pure.test.mjs
+++ b/test/app-pure.test.mjs
@@ -1,0 +1,156 @@
+// Pure functions lifted out of the REAL public/app.js (see helpers/load-app-fns.mjs).
+// app.js is a browser script with no exports, so these are read from source
+// rather than imported — which means renaming or deleting one of them fails
+// here loudly instead of silently passing against a stale copy.
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { loadFns, extractConst } from './helpers/load-app-fns.mjs';
+
+const { prettyUrl, pickContrast, escapeHtml, shade, edgePath } =
+  loadFns(['prettyUrl', 'pickContrast', 'escapeHtml', 'shade', 'edgePath']);
+const URL_RE = extractConst('URL_RE');
+
+describe('prettyUrl — shortens link labels for display', () => {
+  test('drops the scheme and a www. prefix', () => {
+    assert.equal(prettyUrl('https://www.example.com'), 'example.com');
+  });
+
+  test('keeps a meaningful path but drops a trailing slash', () => {
+    assert.equal(prettyUrl('https://example.com/docs/'), 'example.com/docs');
+  });
+
+  test('drops a bare root path entirely', () => {
+    assert.equal(prettyUrl('https://prism.openai.com/'), 'prism.openai.com');
+  });
+
+  test('truncates very long labels with an ellipsis', () => {
+    const label = prettyUrl('https://example.com/' + 'x'.repeat(120));
+    assert.ok(label.length <= 44, `expected <= 44 chars, got ${label.length}`);
+    assert.ok(label.endsWith('\u2026'), 'long labels end with an ellipsis');
+  });
+
+  test('returns the input unchanged when it is not a parseable URL', () => {
+    assert.equal(prettyUrl('not a url'), 'not a url');
+  });
+});
+
+describe('URL_RE — raw URL detection', () => {
+  const matches = s => { URL_RE.lastIndex = 0; return s.match(URL_RE) || []; };
+
+  test('finds a bare URL', () => {
+    assert.deepEqual(matches('see https://example.com now'), ['https://example.com']);
+  });
+
+  test('finds several URLs in one string', () => {
+    assert.equal(matches('https://a.com and https://b.com').length, 2);
+  });
+
+  test('matches http as well as https', () => {
+    assert.equal(matches('http://example.com').length, 1);
+  });
+
+  test('does not match plain text without a scheme', () => {
+    assert.equal(matches('example.com is not matched').length, 0);
+  });
+
+  test('stops at a closing paren so markdown-style links do not over-capture', () => {
+    assert.deepEqual(matches('(https://example.com)'), ['https://example.com']);
+  });
+});
+
+describe('pickContrast — readable text colour for a given background', () => {
+  test('dark text on a light background', () => {
+    assert.equal(pickContrast('#ffffff'), '#23201b');
+    assert.equal(pickContrast('#cfe0ee'), '#23201b', 'the pastel node palette pairs with dark text');
+  });
+
+  test('light text on a dark background', () => {
+    assert.equal(pickContrast('#000000'), '#ffffff');
+    assert.equal(pickContrast('#23201b'), '#ffffff');
+  });
+
+  test('falls back to dark text for malformed input rather than throwing', () => {
+    assert.equal(pickContrast(''), '#23201b');
+    assert.equal(pickContrast(null), '#23201b');
+    assert.equal(pickContrast('#abc'), '#23201b');
+  });
+
+  test('weights green more heavily than blue (per-channel luminance, not a plain average)', () => {
+    // Same numeric value in the dominant channel, opposite results: green-dominant
+    // #40ff40 lands at L=0.691 (dark text), blue-dominant #4040ff at L=0.336
+    // (light text). A naive (r+g+b)/3 average would score both identically.
+    assert.equal(pickContrast('#40ff40'), '#23201b', 'green-dominant reads as light');
+    assert.equal(pickContrast('#4040ff'), '#ffffff', 'blue-dominant reads as dark');
+  });
+});
+
+describe('escapeHtml', () => {
+  test('escapes the characters that could break out of markup', () => {
+    assert.equal(escapeHtml('<script>'), '&lt;script&gt;');
+    assert.equal(escapeHtml('a & b'), 'a &amp; b');
+    assert.equal(escapeHtml('say "hi"'), 'say &quot;hi&quot;');
+  });
+
+  test('handles null and undefined without throwing', () => {
+    assert.equal(escapeHtml(null), '');
+    assert.equal(escapeHtml(undefined), '');
+  });
+
+  test('leaves ordinary text untouched', () => {
+    assert.equal(escapeHtml('plain text 123'), 'plain text 123');
+  });
+});
+
+describe('shade — lighten/darken a hex colour', () => {
+  test('lightens with a positive amount and darkens with a negative one', () => {
+    assert.notEqual(shade('#808080', 40), '#808080');
+    assert.equal(shade('#808080', 0), '#808080');
+  });
+
+  test('clamps at white and black instead of wrapping around', () => {
+    assert.equal(shade('#ffffff', 50), '#ffffff', 'must not overflow past white');
+    assert.equal(shade('#000000', -50), '#000000', 'must not underflow past black');
+  });
+
+  test('always returns a full 6-digit hex colour', () => {
+    for (const [c, amt] of [['#010101', -10], ['#fefefe', 10], ['#123456', 25]]) {
+      assert.match(shade(c, amt), /^#[0-9a-f]{6}$/, `${c} @ ${amt}`);
+    }
+  });
+});
+
+describe('edgePath — branch geometry per map style', () => {
+  const args = (style, horizontal = true) => edgePath(0, 0, 100, 50, false, horizontal, style);
+
+  test('sketch draws a straight line', () => {
+    assert.equal(args('sketch'), 'M0,0 L100,50');
+  });
+
+  test('classic draws right-angle elbows', () => {
+    const p = args('classic');
+    assert.ok(p.includes('L'), 'uses line segments');
+    assert.ok(!p.includes('C'), 'classic must not emit a bezier curve');
+  });
+
+  test('modern draws a bezier curve', () => {
+    assert.ok(args('modern').includes('C'));
+  });
+
+  test('bubble uses the same path shape as modern (CSS makes it thicker)', () => {
+    assert.equal(args('bubble'), args('modern'));
+  });
+
+  test('an unknown style falls back to the modern curve rather than producing nothing', () => {
+    assert.equal(args('no-such-style'), args('modern'));
+  });
+
+  test('every style produces a path starting at the given origin', () => {
+    for (const s of ['sketch', 'classic', 'modern', 'bubble']) {
+      assert.match(args(s), /^M0,0/, `style ${s}`);
+    }
+  });
+
+  test('vertical layout produces a different path than horizontal', () => {
+    assert.notEqual(args('classic', false), args('classic', true));
+  });
+});

--- a/test/auth-core.test.mjs
+++ b/test/auth-core.test.mjs
@@ -1,0 +1,152 @@
+// authorizeRequest() decides who may read, write, or administer a map.
+// It's the highest-consequence pure function in the codebase — a wrong `ok:true`
+// exposes or lets someone edit another user's map. It has also regressed before
+// (linkAccess==='edit' briefly required an identity, breaking anonymous
+// link-editing), which is exactly the kind of change these tests pin down.
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { authorizeRequest } from '../worker/auth-core.js';
+
+const OWNER = { sub: 'user-owner' };
+const OTHER = { sub: 'user-other' };
+
+const aclWith = (over = {}) => ({
+  ownerId: 'user-owner',
+  linkAccess: 'none',
+  members: {},
+  ...over,
+});
+
+describe('authorizeRequest — read', () => {
+  test('a map with no ACL at all is readable by anyone (pre-ACL legacy maps)', () => {
+    const r = authorizeRequest({ acl: null, need: 'read' });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'open-legacy');
+  });
+
+  test('owner can read', () => {
+    const r = authorizeRequest({ acl: aclWith(), identity: OWNER, need: 'read' });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'owner');
+  });
+
+  test('a viewer member can read', () => {
+    const acl = aclWith({ members: { 'user-other': { role: 'viewer' } } });
+    const r = authorizeRequest({ acl, identity: OTHER, need: 'read' });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'viewer');
+  });
+
+  test('a stranger CANNOT read a private map', () => {
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'none' }), identity: OTHER, need: 'read' });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 403, 'authenticated but unauthorised is 403, not 401');
+  });
+
+  test('an anonymous visitor CANNOT read a private map, and gets 401 not 403', () => {
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'none' }), need: 'read' });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 401, 'no identity means 401 so the client knows to sign in');
+  });
+
+  test("linkAccess 'view' lets an anonymous visitor read", () => {
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'view' }), need: 'read' });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'link-viewer');
+  });
+
+  test("linkAccess 'edit' also implies read for anonymous visitors", () => {
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'edit' }), need: 'read' });
+    assert.equal(r.ok, true);
+  });
+
+  test("linkAccess 'view-auth' requires a signed-in user", () => {
+    const acl = aclWith({ linkAccess: 'view-auth' });
+    assert.equal(authorizeRequest({ acl, need: 'read' }).ok, false, 'anonymous is refused');
+    assert.equal(authorizeRequest({ acl, identity: OTHER, need: 'read' }).ok, true, 'signed-in is allowed');
+  });
+});
+
+describe('authorizeRequest — write', () => {
+  test('owner can write', () => {
+    const r = authorizeRequest({ acl: aclWith(), identity: OWNER, need: 'write' });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'owner');
+  });
+
+  test('an editor member can write', () => {
+    const acl = aclWith({ members: { 'user-other': { role: 'editor' } } });
+    assert.equal(authorizeRequest({ acl, identity: OTHER, need: 'write' }).ok, true);
+  });
+
+  test('a VIEWER member cannot write (rank must be >= editor)', () => {
+    const acl = aclWith({ members: { 'user-other': { role: 'viewer' } } });
+    const r = authorizeRequest({ acl, identity: OTHER, need: 'write' });
+    assert.equal(r.ok, false, 'read access must not imply write access');
+  });
+
+  test("linkAccess 'edit' allows an ANONYMOUS editor — no identity, no token", () => {
+    // Regression guard: this branch was once tightened to require an identity,
+    // which silently broke every "anyone with the link can edit" map.
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'edit' }), need: 'write' });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'link-editor');
+  });
+
+  test("linkAccess 'edit-auth' requires sign-in to write", () => {
+    const acl = aclWith({ linkAccess: 'edit-auth' });
+    assert.equal(authorizeRequest({ acl, need: 'write' }).ok, false, 'anonymous refused');
+    assert.equal(authorizeRequest({ acl, identity: OTHER, need: 'write' }).ok, true, 'signed-in allowed');
+  });
+
+  test("linkAccess 'view' does NOT grant write", () => {
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'view' }), need: 'write' });
+    assert.equal(r.ok, false, 'view-only links must never permit edits');
+  });
+
+  test('with no ACL, a matching legacy edit token grants write', () => {
+    const r = authorizeRequest({ acl: null, editToken: 'secret', tokenHeader: 'secret', need: 'write', allowClaim: false });
+    assert.equal(r.ok, true);
+    assert.equal(r.role, 'link-editor');
+  });
+
+  test('with no ACL, a NON-matching token is refused', () => {
+    const r = authorizeRequest({ acl: null, editToken: 'secret', tokenHeader: 'wrong', need: 'write', allowClaim: false });
+    assert.equal(r.ok, false);
+  });
+
+  test('with no ACL and no token, the first write claims the token', () => {
+    const r = authorizeRequest({ acl: null, need: 'write' });
+    assert.equal(r.ok, true);
+    assert.equal(r.claimToken, true);
+  });
+});
+
+describe('authorizeRequest — admin', () => {
+  test('owner can administer', () => {
+    assert.equal(authorizeRequest({ acl: aclWith(), identity: OWNER, need: 'admin' }).ok, true);
+  });
+
+  test('an EDITOR member cannot administer (only the owner may)', () => {
+    const acl = aclWith({ members: { 'user-other': { role: 'editor' } } });
+    const r = authorizeRequest({ acl, identity: OTHER, need: 'admin' });
+    assert.equal(r.ok, false, 'editors must not be able to change sharing/ACL');
+  });
+
+  test('an anonymous visitor can never administer, even on a public-edit map', () => {
+    const r = authorizeRequest({ acl: aclWith({ linkAccess: 'edit' }), need: 'admin' });
+    assert.equal(r.ok, false);
+    assert.equal(r.status, 401);
+  });
+
+  test('the first authenticated user claims an unowned map', () => {
+    const r = authorizeRequest({ acl: null, identity: OTHER, need: 'admin' });
+    assert.equal(r.ok, true);
+    assert.equal(r.claim, true);
+  });
+
+  test('claiming can be disabled with allowClaim:false', () => {
+    const r = authorizeRequest({ acl: null, identity: OTHER, need: 'admin', allowClaim: false });
+    assert.equal(r.ok, false);
+  });
+});

--- a/test/helpers/load-app-fns.mjs
+++ b/test/helpers/load-app-fns.mjs
@@ -1,0 +1,73 @@
+// public/app.js is a plain browser script with no module exports — it can't be
+// imported. Rather than copy functions into the tests (where they'd silently
+// drift from the shipped code the first time someone edits app.js), this reads
+// the REAL source and lifts out individual top-level function declarations by
+// brace-matching, then evaluates them in an isolated scope.
+//
+// Consequence worth knowing: if someone renames or deletes one of these
+// functions, the affected test fails loudly at load time rather than passing
+// against a stale copy. That's the point.
+import { readFileSync } from 'node:fs';
+import { fileURLToPath } from 'node:url';
+import { dirname, join } from 'node:path';
+
+const here = dirname(fileURLToPath(import.meta.url));
+const APP_JS = join(here, '..', '..', 'public', 'app.js');
+
+let _src = null;
+function source() {
+  if (_src === null) _src = readFileSync(APP_JS, 'utf8');
+  return _src;
+}
+
+/**
+ * Extract the full text of a top-level `function NAME(...) { ... }`.
+ *
+ * Finds the end by asking the JS parser rather than brace-counting by hand:
+ * try each following `}` as a candidate end and return the first slice that
+ * compiles as a function expression. Hand-rolled brace matching needs a full
+ * lexer to avoid tripping over braces and quotes inside strings, template
+ * literals, regexes and comments — app.js has all four (escapeHtml's
+ * /[&<>"]/g regex is enough to break the naive version).
+ */
+export function extractFunction(name) {
+  const src = source();
+  const re = new RegExp(`^(?:async\\s+)?function\\s+${name}\\s*\\(`, 'm');
+  const m = re.exec(src);
+  if (!m) throw new Error(`load-app-fns: function ${name}() not found in public/app.js`);
+
+  const start = m.index;
+  for (let i = src.indexOf('{', start); i !== -1; i = src.indexOf('}', i + 1)) {
+    if (src[i] !== '}') continue;
+    const candidate = src.slice(start, i + 1);
+    try {
+      // Throws unless `candidate` is a complete, syntactically valid function.
+      new Function(`return (${candidate});`);
+      return candidate;
+    } catch { /* not the end yet — keep going */ }
+  }
+  throw new Error(`load-app-fns: could not find the end of ${name}()`);
+}
+
+/**
+ * Build callable versions of the named functions.
+ * `deps` supplies anything they close over that isn't a JS/Node global.
+ */
+export function loadFns(names, deps = {}) {
+  const bodies = names.map(extractFunction).join('\n\n');
+  const depNames = Object.keys(deps);
+  const factory = new Function(
+    ...depNames,
+    `${bodies}\nreturn { ${names.join(', ')} };`
+  );
+  return factory(...depNames.map(k => deps[k]));
+}
+
+/** Extract a top-level `const NAME = ...;` single-line declaration (e.g. a regex). */
+export function extractConst(name) {
+  const src = source();
+  const re = new RegExp(`^const\\s+${name}\\s*=\\s*(.+?);\\s*$`, 'm');
+  const m = re.exec(src);
+  if (!m) throw new Error(`load-app-fns: const ${name} not found in public/app.js`);
+  return new Function(`return (${m[1]});`)();
+}

--- a/test/import-core.test.mjs
+++ b/test/import-core.test.mjs
@@ -1,0 +1,193 @@
+// buildMapFromSpec() is reached from the PUBLIC, unauthenticated /api/import
+// endpoint, so it is the app's main untrusted-input surface. These tests pin
+// down its validation rules and confirm hostile input can't corrupt the runtime.
+import { test, describe } from 'node:test';
+import assert from 'node:assert/strict';
+import { buildMapFromSpec } from '../worker/import-core.js';
+
+const spec = (over = {}) => ({
+  title: 'Test map',
+  nodes: [
+    { id: 'r', text: 'Root', parent: null },
+    { id: 'a', text: 'Child A', parent: 'r' },
+  ],
+  ...over,
+});
+
+describe('buildMapFromSpec — rejects malformed input', () => {
+  const bad = [
+    ['null body', null],
+    ['a string body', 'not an object'],
+    ['a number body', 42],
+    ['no nodes key', { title: 'x' }],
+    ['an empty nodes array', { nodes: [] }],
+    ['nodes not an array', { nodes: 'nope' }],
+  ];
+  for (const [label, input] of bad) {
+    test(`throws on ${label}`, () => {
+      assert.throws(() => buildMapFromSpec(input));
+    });
+  }
+
+  test('throws when a node has no id', () => {
+    assert.throws(() => buildMapFromSpec({ nodes: [{ text: 'x', parent: null }] }), /non-empty string id/);
+  });
+
+  test('throws when a node is missing text', () => {
+    assert.throws(() => buildMapFromSpec({ nodes: [{ id: 'r', parent: null }] }), /missing text/);
+  });
+
+  test('throws on duplicate node ids', () => {
+    const s = { nodes: [{ id: 'r', text: 'a', parent: null }, { id: 'r', text: 'b', parent: 'r' }] };
+    assert.throws(() => buildMapFromSpec(s), /duplicate node id/);
+  });
+
+  test('throws when a node points at a parent that does not exist', () => {
+    const s = { nodes: [{ id: 'r', text: 'a', parent: null }, { id: 'b', text: 'b', parent: 'ghost' }] };
+    assert.throws(() => buildMapFromSpec(s), /missing parent/);
+  });
+
+  test('throws when rootId names a node that does not exist', () => {
+    assert.throws(() => buildMapFromSpec(spec({ rootId: 'ghost' })), /rootId does not match/);
+  });
+
+  test('throws when there is more than one parent-less node and no rootId', () => {
+    const s = { nodes: [{ id: 'a', text: 'a', parent: null }, { id: 'b', text: 'b', parent: null }] };
+    assert.throws(() => buildMapFromSpec(s), /exactly one root/);
+  });
+
+  test('throws on a node that is its own parent', () => {
+    const s = { rootId: 'r', nodes: [{ id: 'r', text: 'r', parent: null }, { id: 'a', text: 'a', parent: 'a' }] };
+    assert.throws(() => buildMapFromSpec(s));
+  });
+
+  test('detects a parent cycle rather than hanging forever', () => {
+    // a -> b -> a never reaches the root; without the hop guard this loops.
+    const s = {
+      rootId: 'r',
+      nodes: [
+        { id: 'r', text: 'r', parent: null },
+        { id: 'a', text: 'a', parent: 'b' },
+        { id: 'b', text: 'b', parent: 'a' },
+      ],
+    };
+    assert.throws(() => buildMapFromSpec(s), /cycle detected/);
+  });
+});
+
+describe('buildMapFromSpec — builds a valid map', () => {
+  test('produces the expected shape', () => {
+    const m = buildMapFromSpec(spec());
+    assert.equal(m.rootId, 'r');
+    assert.equal(m.title, 'Test map');
+    assert.equal(m.layout, 'balanced');
+    assert.equal(Object.keys(m.nodes).length, 2);
+    assert.equal(m.nodes.r.parent, null, 'root must have a null parent');
+    assert.equal(m.nodes.r.side, 'root');
+  });
+
+  test('falls back to a default title when none is usable', () => {
+    assert.equal(buildMapFromSpec(spec({ title: '   ' })).title, 'Imported map');
+    assert.equal(buildMapFromSpec(spec({ title: 42 })).title, 'Imported map');
+  });
+
+  test('infers the root from the single parent-less node', () => {
+    assert.equal(buildMapFromSpec({ nodes: [{ id: 'solo', text: 'x', parent: null }] }).rootId, 'solo');
+  });
+
+  test('balances root children — first half right, second half left', () => {
+    const nodes = [{ id: 'r', text: 'r', parent: null }];
+    for (let i = 0; i < 5; i++) nodes.push({ id: 'c' + i, text: 'c', parent: 'r' });
+    const m = buildMapFromSpec({ rootId: 'r', nodes });
+    const sides = ['c0', 'c1', 'c2', 'c3', 'c4'].map(id => m.nodes[id].side);
+    assert.deepEqual(sides, ['right', 'right', 'right', 'left', 'left']);
+  });
+
+  test('keeps only links whose endpoints both exist', () => {
+    const m = buildMapFromSpec(spec({
+      links: [
+        { from: 'r', to: 'a', label: 'ok' },
+        { from: 'r', to: 'ghost' },   // dropped
+        null,                          // dropped
+      ],
+    }));
+    assert.equal(m.links.length, 1);
+    assert.equal(m.links[0].label, 'ok');
+  });
+
+  test('carries through optional formatting without inventing values', () => {
+    const m = buildMapFromSpec({
+      rootId: 'r',
+      nodes: [
+        { id: 'r', text: 'r', parent: null },
+        { id: 'a', text: 'a', parent: 'r', bold: true, task: 'done', listType: 'ul', align: 'right' },
+        { id: 'b', text: 'b', parent: 'r' },
+      ],
+    });
+    assert.equal(m.nodes.a.bold, true);
+    assert.equal(m.nodes.a.task, 'done');
+    assert.equal(m.nodes.a.listType, 'ul');
+    assert.equal(m.nodes.b.bold, undefined, 'flags must not be set on nodes that did not ask for them');
+  });
+
+  test('ignores an invalid task value rather than storing it', () => {
+    const m = buildMapFromSpec({
+      rootId: 'r',
+      nodes: [{ id: 'r', text: 'r', parent: null }, { id: 'a', text: 'a', parent: 'r', task: 'bogus' }],
+    });
+    assert.equal(m.nodes.a.task, undefined);
+  });
+
+  test('normalises a citation and marks the node as a reference', () => {
+    const m = buildMapFromSpec({
+      rootId: 'r',
+      nodes: [{
+        id: 'r', text: 'r', parent: null,
+        citation: { authors: ['Smith', 'Jones'], year: 2024, title: 'A Study', doi: '10.1/x' },
+      }],
+    });
+    assert.equal(m.nodes.r.citation.authors, 'Smith, Jones');
+    assert.equal(m.nodes.r.ref, true);
+  });
+
+  test('an arXiv id becomes a doi and implies the arXiv source', () => {
+    const m = buildMapFromSpec({
+      rootId: 'r',
+      nodes: [{ id: 'r', text: 'r', parent: null, citation: { arxiv: '2401.00001' } }],
+    });
+    assert.equal(m.nodes.r.citation.doi, 'arXiv:2401.00001');
+    assert.equal(m.nodes.r.citation.source, 'arXiv');
+  });
+});
+
+describe('buildMapFromSpec — hostile input', () => {
+  test('a __proto__ key in the spec does not pollute Object.prototype', () => {
+    const payload = JSON.parse(
+      '{"title":"evil","nodes":[{"id":"r","text":"r","parent":null}],"__proto__":{"polluted":"yes"}}'
+    );
+    buildMapFromSpec(payload);
+    assert.equal({}.polluted, undefined, 'Object.prototype must be untouched');
+  });
+
+  test('a __proto__ key inside a node does not pollute Object.prototype', () => {
+    const payload = JSON.parse(
+      '{"nodes":[{"id":"r","text":"r","parent":null,"__proto__":{"polluted2":"yes"}}]}'
+    );
+    buildMapFromSpec(payload);
+    assert.equal({}.polluted2, undefined);
+  });
+
+  test('a node id of "__proto__" does not corrupt the nodes map', () => {
+    const m = buildMapFromSpec({
+      rootId: '__proto__',
+      nodes: [{ id: '__proto__', text: 'sneaky', parent: null }],
+    });
+    assert.equal({}.text, undefined, 'writing that id must not reach Object.prototype');
+    assert.equal(typeof m.nodes, 'object');
+  });
+
+  test('text is coerced to a string rather than kept as an object', () => {
+    const m = buildMapFromSpec({ nodes: [{ id: 'r', text: 'plain', parent: null }] });
+    assert.equal(typeof m.nodes.r.text, 'string');
+  });
+});


### PR DESCRIPTION
76 tests, zero new dependencies — `node:test` only, matching the project's
zero-dependency philosophy.

## Coverage

Targets the highest-consequence logic rather than a coverage percentage:

- **`worker/auth-core.js` — `authorizeRequest()`** (22 tests): the full
  read/write/admin matrix. Decides who can view and edit a map, and has
  regressed before — `linkAccess='edit'` briefly required an identity,
  silently breaking every "anyone with the link can edit" map.
- **`worker/import-core.js` — `buildMapFromSpec()`** (27 tests): the public,
  unauthenticated import endpoint. Structural validation, cycle detection,
  and prototype-pollution resistance.
- **`public/app.js` pure functions** (27 tests): `prettyUrl`, `pickContrast`,
  `escapeHtml`, `shade`, `edgePath`, `URL_RE`.

## How app.js is tested

`app.js` is a browser script with no module exports, so `test/helpers/load-app-fns.mjs`
reads the **real source** and lifts out function declarations rather than
copying them into the tests — a copy would silently drift the first time
someone edits `app.js`. Renaming or deleting one of those functions now fails
loudly instead of passing against a stale copy.

## CI

Runs on push and PR:
- `npm test`
- `node --check` on every tracked `.js`/`.mjs` file
- YAML validation of all workflow and issue-template files
- smoke test: boots the server, asserts `/`, `/app.js`, `/styles.css` and
  `/api/maps` all return 200

The YAML step would have caught both real bugs in the container-publish PR
(#4) before review.

## Verification

Mutation tested, not just run green — reintroducing the anonymous-edit
regression and a viewer→writer privilege escalation each fail exactly the
test written for them, and pass again on revert.