### PR TITLE
fix: the collab-http in collab-http.js

### DIFF
--- a/worker/collab-http.js
+++ b/worker/collab-http.js
@@ -32,12 +32,14 @@ async function applyClaims(storage, d, ident, acl, editToken, request){
   }
   return acl;
 }
+const UNSAFE_KEYS = new Set(['__proto__', 'constructor', 'prototype']);
+function isSafeKey(k){ return typeof k === 'string' && !UNSAFE_KEYS.has(k); }
 function applyOps(snap, ops){
   snap.nodes = snap.nodes || {};
   for(const op of (ops || [])){
-    if(op && op.t === 'node' && op.id) snap.nodes[op.id] = op.n;
-    else if(op && op.t === 'del' && op.id) delete snap.nodes[op.id];
-    else if(op && op.t === 'meta' && op.k) snap[op.k] = op.v;
+    if(op && op.t === 'node' && op.id && isSafeKey(op.id)) snap.nodes[op.id] = op.n;
+    else if(op && op.t === 'del' && op.id && isSafeKey(op.id)) delete snap.nodes[op.id];
+    else if(op && op.t === 'meta' && op.k && isSafeKey(op.k)) snap[op.k] = op.v;
   }
   return snap;
 }
@@ -78,6 +80,7 @@ export async function handleCollabHttp(storage, env, request){
       const uid = String((b && b.userId) || '').trim();
       const role = (b && b.role === 'viewer') ? 'viewer' : 'editor';
       if(!uid) return { status: 400, body: { error: 'userId required' } };
+      if(!isSafeKey(uid)) return { status: 400, body: { error: 'invalid userId' } };
       if(uid === String(cur.ownerId)) return { status: 400, body: { error: 'already the owner' } };
       cur.members = cur.members || {};
       cur.members[uid] = { role, login: String((b && b.login) || '') };


### PR DESCRIPTION
## Summary
Fix high severity security issue in `worker/collab-http.js`.

## Vulnerability
| Field | Value |
|-------|-------|
| **ID** | V-001 |
| **Severity** | HIGH |
| **Scanner** | multi_agent_ai |
| **Rule** | `V-001` |
| **File** | `worker/collab-http.js:77` |
| **Assessment** | Likely exploitable |
| **Chain Complexity** | 2-step |

**Description**: The collab-http.js endpoints parse JSON request bodies without schema validation or prototype pollution sanitization. Parsed objects are directly used in operations like ACL member addition and map operations. An attacker can inject __proto__, constructor, or prototype properties to pollute JavaScript's Object.prototype, potentially affecting application logic or causing denial of service.

## Evidence

**Scanner confirmation**: multi_agent_ai rule `V-001` flagged this pattern.

**Production code**: This file is in the production codebase, not test-only code.

## Threat Model Context

This is a Node.js library - vulnerabilities affect downstream consumers who use this package.

## Changes
- `worker/collab-http.js`

## Behavior Preservation
The change is scoped to 1 file on the vulnerable path; it only tightens handling of untrusted input and leaves valid inputs unaffected.

---
*Automated security fix by [OrbisAI Security](https://orbisappsec.com)*
